### PR TITLE
Add Hollow Knight-style dash flow to obj_player

### DIFF
--- a/game/objects/obj_player/Create_0.gml
+++ b/game/objects/obj_player/Create_0.gml
@@ -14,6 +14,7 @@ enum PlayerState {
 	ATTACK,
 	TALKING,
 	WAIT_ATTACK,
+	DASH,
 	DYING
 }
 state = PlayerState.IDLE;
@@ -85,6 +86,16 @@ run = false;
 tap_timer_left = 0;
 tap_timer_right = 0;
 double_tap_threshold = 15;
+
+// Dash
+dash_speed = 11;
+dash_duration = 8;
+dash_cooldown = 18;
+dash_timer = 0;
+dash_cooldown_timer = 0;
+dash_direction = 1;
+is_dashing = false;
+air_dash_available = true;
 
 previous_state = state;
 smoke_instance = noone;

--- a/game/objects/obj_player/Step_0.gml
+++ b/game/objects/obj_player/Step_0.gml
@@ -55,6 +55,7 @@ switch (state) {
     case PlayerState.FALL:
     case PlayerState.ATTACK:
 	case PlayerState.TALKING:
+	case PlayerState.DASH:
 		scr_combat();
 	case PlayerState.DYING:
 		scr_movement(); 

--- a/game/scripts/scr_combat/scr_combat.gml
+++ b/game/scripts/scr_combat/scr_combat.gml
@@ -1,6 +1,10 @@
 function scr_combat() {
 	damage = damage_base;
 
+	if (is_dashing) {
+		return;
+	}
+
     if (keyboard_check_pressed(ord("Z")) && alarm[1] <= 0 && !talking) {
 
 		if(instance_exists(obj_perk_passive_energy_attack)) obj_perk_passive_energy_attack.count_attack++;

--- a/game/scripts/scr_movement/scr_movement.gml
+++ b/game/scripts/scr_movement/scr_movement.gml
@@ -40,10 +40,16 @@ else
 
 	    if (tap_timer_left > 0) tap_timer_left--;
 	    if (tap_timer_right > 0) tap_timer_right--;
-	
+    if (dash_cooldown_timer > 0) dash_cooldown_timer--;
 
-	    // === GRAVITY ===
-	    vsp += grv;
+    if (ong) {
+        air_dash_available = true;
+    }
+
+    // === GRAVITY ===
+    if (!is_dashing) {
+        vsp += grv;
+    }
 	
 	    // === MOVEMENT ===
 		
@@ -69,7 +75,26 @@ else
 	        else if (keyboard_check(vk_left)) {move_input = -1; turn_target_dir = move_input;}
 			}
 
-	        if (move_input != 0 && move_input != face && !turning) {
+	        var wants_dash = keyboard_check_pressed(vk_shift);
+	        var can_dash = !talking && !is_dashing && dash_cooldown_timer <= 0 && (ong || air_dash_available);
+
+	        if (wants_dash && can_dash) {
+	            is_dashing = true;
+	            dash_timer = dash_duration;
+	            dash_cooldown_timer = dash_cooldown;
+	            dash_direction = (move_input != 0) ? move_input : face;
+	            face = dash_direction;
+	            run = false;
+	            turning = false;
+	            hsp = dash_direction * dash_speed;
+	            vsp = 0;
+
+	            if (!ong) {
+	                air_dash_available = false;
+	            }
+	        }
+
+	        if (move_input != 0 && move_input != face && !turning && !is_dashing) {
 	            turning = true;
 	            turn_timer = 0;
 	            turn_duration = 10;
@@ -83,7 +108,17 @@ else
             
 	        }
 
-	        if (turning) {
+	        if (is_dashing) {
+            dash_timer--;
+            hsp = dash_direction * dash_speed;
+            vsp = 0;
+
+            if (dash_timer <= 0) {
+                is_dashing = false;
+                hsp = 0;
+            }
+        }
+        else if (turning) {
 	            turn_timer++;
 	            var target_spd = turn_target_dir * (base_spd * 0.5);
 	            hsp = lerp(hsp, target_spd, accel);
@@ -104,7 +139,7 @@ else
 	            }
 	        }
 
-			if(!talking){
+			if(!talking && !is_dashing){
 		        if (!keyboard_check(vk_right) && !keyboard_check(vk_left)) {
 		            if (abs(hsp) < 1 && !turning) run = false;
 		        }
@@ -179,10 +214,15 @@ else
 		        x += sign(hsp);
 		    }
 		    hsp = 0;
+		    if (is_dashing) {
+		        is_dashing = false;
+		        dash_timer = 0;
+		    }
 		}
 		x += hsp;
 
 		// VERTICAL
+		var previous_ong = ong;
 		ong = false;
 		if (col(x, y + vsp)) {
 		    while (!col(x, y + sign(vsp))) {
@@ -191,7 +231,13 @@ else
 		    if (vsp > 0) ong = true;
 		    vsp = 0;
 		}
-		y += vsp;
+		if (!is_dashing) {
+			y += vsp;
+		}
+
+		if (ong && !previous_ong) {
+			air_dash_available = true;
+		}
 
 
 	    // === KNOCKBACK ===
@@ -213,12 +259,18 @@ else
 		
 	    if (state != PlayerState.ATTACK) {
 
-			if (swimming) {
+			if (is_dashing) {
+				state = PlayerState.DASH;
+				sprite_index = spr_player_running;
+				image_speed = 1.5;
+			}
+
+			if (swimming && !is_dashing) {
 				vsp *= 0.75;
 				hsp *= 0.75;
 			}
 
-	        if (!ong) {
+	        if (!is_dashing && !ong) {
 	            // --- ON AIR ---
 	            if (vsp < 0) {
 	                if (state != PlayerState.JUMP && state != PlayerState.RUN_JUMP) {


### PR DESCRIPTION
### Motivation
- Implementar um movimento de dash que bloqueie ações durante o dash e só permita dash novamente ao tocar o chão, com um cooldown mínimo para evitar spam.

### Description
- Adiciona novo estado `DASH` e variáveis configuráveis de dash (`dash_speed`, `dash_duration`, `dash_cooldown`, timers, `is_dashing`, `air_dash_available`) no `Create` de `obj_player` (`game/objects/obj_player/Create_0.gml`).
- Implementa entrada de dash com `Shift` em `scr_movement` e lógica que inicia o dash, aplica `hsp`, segura `vsp`, decrementa `dash_timer`, cancela o dash ao colidir com parede, e restaura a disponibilidade de dash ao tocar o chão (`game/scripts/scr_movement/scr_movement.gml`).
- Bloqueia pulos/movimento/combate durante o dash e evita dashes repetidos com `dash_cooldown_timer` e uma única execução de dash no ar por salto (reseta ao pousar). 
- Atualiza o dispatcher do `Step` para incluir `PlayerState.DASH` e previne ações de combate enquanto `is_dashing` em `scr_combat` (`game/objects/obj_player/Step_0.gml`, `game/scripts/scr_combat/scr_combat.gml`).

### Testing
- Verifiquei a presença das novas variáveis e do estado `DASH` abrindo `Create_0.gml`, `Step_0.gml`, `scr_movement.gml` e `scr_combat.gml` via inspeção de arquivo; todas as inserções esperadas foram encontradas (patterns presentes).
- Executei busca por padrões com `rg` para `dash`, `is_dashing` e `PlayerState.DASH` e confirmei as ocorrências nos arquivos modificados; a verificação obteve os resultados esperados.
- Inspecionei trechos relevantes com `sed`/`nl` para confirmar comportamento de gravidade, triggers de dash, cancelamento em paredes e reset ao pouso; as alterações foram aplicadas com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc5e0134832b90e5637e5556ccd4)